### PR TITLE
Fix clicking on the clhs and crhs elements

### DIFF
--- a/lib/mergely.js
+++ b/lib/mergely.js
@@ -1387,13 +1387,13 @@ jQuery.extend(Mgly.mergely.prototype, {
 		ctx_rhs.fillRect(1.5, from, 4.5, to);
 		
 		ex.clhs.click(function (ev) {
-			var y = ev.pageY - lhs_xyoffset.top - (to / 2);
-			var sto = Math.max(0, (y / ex.mcanvas_lhs.height) * ex.lhs_scroller.get(0).scrollHeight);
+			var y = ev.pageY - ex.lhs_xyoffset.top - (to / 2);
+			var sto = Math.max(0, (y / mcanvas_lhs.height) * ex.lhs_scroller.get(0).scrollHeight);
 			ex.lhs_scroller.scrollTop(sto);
 		});
 		ex.crhs.click(function (ev) {
-			var y = ev.pageY - rhs_xyoffset.top - (to / 2);
-			var sto = Math.max(0, (y / ex.mcanvas_rhs.height) * ex.rhs_scroller.get(0).scrollHeight);
+			var y = ev.pageY - ex.rhs_xyoffset.top - (to / 2);
+			var sto = Math.max(0, (y / mcanvas_rhs.height) * ex.rhs_scroller.get(0).scrollHeight);
 			ex.rhs_scroller.scrollTop(sto);
 		});
 	},


### PR DESCRIPTION
You used to be able to click on the side canvas elements to scroll to a location, but that seems broken (error listed below).  This PR attempts to fix that.  I've not very familiar with the code, so please review carefully.

```
Uncaught ReferenceError: lhs_xyoffset is not defined 
```

Thanks.
