### PR TITLE
Issue with misaligned canvas when editors move relative to top of document.

### DIFF
--- a/lib/mergely.js
+++ b/lib/mergely.js
@@ -573,6 +573,7 @@ jQuery.extend(Mgly.CodeMirrorDiffView.prototype, {
 	resize: function() {
 		this.settings.resize();
 		this._changing(this.id + '-lhs', this.id + '-rhs');
+		this._set_top_offset(this.id + '-lhs');
 	},
 	diff: function() {
 		var lhs = this.editor[this.id + '-lhs'].getValue();
@@ -894,13 +895,27 @@ jQuery.extend(Mgly.CodeMirrorDiffView.prototype, {
 		}
 		return true;
 	},
+	_set_top_offset: function (editor_name1) {
+		// save the current scroll position of the editor
+		var saveY = this.editor[editor_name1].getScrollInfo().top;
+		// temporarily scroll to top
+		this.editor[editor_name1].scrollTo(null, 0);
+		
+		// this is the distance from the top of the screen to the top of the 
+		// content of the first codemirror editor
+		var topnode = jQuery('#' + this.id + ' .CodeMirror-measure').first();
+		var top_offset = topnode.offset().top - 4;
+		if(!top_offset) return false;
+		
+		// restore editor's scroll position
+		this.editor[editor_name1].scrollTo(null, saveY);
+		
+		this.draw_top_offset = 0.5 - top_offset;
+		return true;
+	},
 	_calculate_offsets: function (editor_name1, editor_name2, changes) {
 		if (this.em_height == null) {
-			// this is the distance from the top of the screen
-			var topnode = jQuery('#' + this.id + ' .CodeMirror-measure').first();
-			var top_offset = topnode.offset().top - 4;
-			if (!top_offset) return;//try again
-			this.draw_top_offset = 0.5 - top_offset;
+			if(!this._set_top_offset(editor_name1)) return; //try again
 			this.em_height = this.editor[editor_name1].defaultTextHeight();
 			if (!this.em_height) {
 				console.warn('Failed to calculate offsets, using 18 by default');
@@ -919,7 +934,7 @@ jQuery.extend(Mgly.CodeMirrorDiffView.prototype, {
 			this.draw_rhs_max = this.draw_mid_width - 0.5; //24.5;
 			this.draw_lhs_width = 5;
 			this.draw_rhs_width = 5;
-			this.trace('calc', 'change offsets calculated', {top_offset: top_offset, lhs_min: this.draw_lhs_min, rhs_max: this.draw_rhs_max, lhs_width: this.draw_lhs_width, rhs_width: this.draw_rhs_width});
+			this.trace('calc', 'change offsets calculated', {top_offset: this.draw_top_offset, lhs_min: this.draw_lhs_min, rhs_max: this.draw_rhs_max, lhs_width: this.draw_lhs_width, rhs_width: this.draw_rhs_width});
 		}
 		var lhschc = this.editor[editor_name1].charCoords({line: 0});
 		var rhschc = this.editor[editor_name2].charCoords({line: 0});


### PR DESCRIPTION
Hi Jamie, thanks for Mergely, I'm finding it to be a great utility. I came across an issue where the canvases would become misaligned if the CodeMirror editors were repositioned relative to the top of the document. I discovered this  in working on a project involving toggling on and off a "full-screen" view of a file comparison. It can be solved by recalculating the draw_top_offset property after the editors have been repositioned. You'll probably have a better way to solve this, but here's a patch as a starting point for thought. This approach at least satisfies my needs; it does the recalculation when resize is invoked (but not auto-resize, since I always know when the editors are moved and I can call resize at that time).
