### PR TITLE
Fixed scrollbar positions for synced scrolling

### DIFF
--- a/lib/mergely.js
+++ b/lib/mergely.js
@@ -811,9 +811,8 @@ jQuery.extend(Mgly.CodeMirrorDiffView.prototype, {
 			if (scroll || force_scroll) {
 				// scroll the other side
 				this.trace('scroll', 'scrolling other side', top_to - top_adjust);
-				scroller = jQuery(this.editor[name].getScrollerElement());
 				this._skipscroll[name] = true;//disable next event
-				scroller.scrollTop(top_to - top_adjust).scrollLeft(left_to);
+				this.editor[name].scrollTo(left_to, top_to - top_adjust);
 			}
 			else this.trace('scroll', 'not scrolling other side');
 			


### PR DESCRIPTION
This fixes some problems with the synced scrolling.
For example:
If one of your sides has a vertical scrollbar while the other has not, scrolling horizontal causes the side with vertical scrollbar to scroll. Unfortunately the position of the scroll bar was not synced accurate.

Feel free to accept my pull request, if you like it.

With kind regards
