### PR TITLE
Removed resize handler on teardown

### DIFF
--- a/lib/mergely.js
+++ b/lib/mergely.js
@@ -468,6 +468,7 @@ jQuery.extend(Mgly.CodeMirrorDiffView.prototype, {
 		if (this.changed_timeout != null) clearTimeout(this.changed_timeout);
 		this.editor[this.id + '-lhs'].toTextArea();
 		this.editor[this.id + '-rhs'].toTextArea();
+		jQuery(window).off('.mergely');
 	},
 	destroy: function() {
 		this.element.unbind('destroyed', this.teardown);
@@ -699,7 +700,7 @@ jQuery.extend(Mgly.CodeMirrorDiffView.prototype, {
 					self._changing(self.id + '-lhs', self.id + '-rhs');
 				}
 			};
-			jQuery(window).resize(
+			jQuery(window).on('resize.mergely',
 				function () {
 					if (sz_timeout1) clearTimeout(sz_timeout1);
 					sz_timeout1 = setTimeout(sz, self.settings.resize_timeout);


### PR DESCRIPTION
The [resize handler] (https://github.com/wickedest/Mergely/blob/master/lib/mergely.js#L702-707) registered on window during `bind` was never removed during `unbind`, which caused a memory leak and "Failed to find canvas" exceptions after `destroy`ing mergely.

I simply namespace the resize event and on `unbind` I remove it alongside all  `mergely` namespaced events.