### PR TITLE
correction in canvas drawing for editor position

### DIFF
--- a/lib/mergely.js
+++ b/lib/mergely.js
@@ -1377,11 +1377,15 @@ jQuery.extend(Mgly.CodeMirrorDiffView.prototype, {
 		var ctx_lhs = mcanvas_lhs.getContext('2d');
 		var ctx_rhs = mcanvas_rhs.getContext('2d');
 
+		var scrollOffset = this.element.position().top;
+		var lhs_adjusted_scroll = ex.lhs_scroller.scrollTop() - scrollOffset;
+		var rhs_adjusted_scroll = ex.rhs_scroller.scrollTop() - scrollOffset;
+
 		this.trace('draw', 'visible_page_height', ex.visible_page_height);
 		this.trace('draw', 'gutter_height', ex.gutter_height);
 		this.trace('draw', 'visible_page_ratio', ex.visible_page_ratio);
-		this.trace('draw', 'lhs-scroller-top', ex.lhs_scroller.scrollTop());
-		this.trace('draw', 'rhs-scroller-top', ex.rhs_scroller.scrollTop());
+		this.trace('draw', 'lhs-scroller-top', lhs_adjusted_scroll);
+		this.trace('draw', 'rhs-scroller-top', rhs_adjusted_scroll);
 		
 		jQuery.each(jQuery.find('#' + this.id + ' canvas'), function () {
 			jQuery(this).get(0).height = ex.visible_page_height;
@@ -1408,10 +1412,10 @@ jQuery.extend(Mgly.CodeMirrorDiffView.prototype, {
 
 			this.trace('draw', change);
 			// margin indicators
-			var lhs_y_start = ((change['lhs-y-start'] + ex.lhs_scroller.scrollTop()) * ex.visible_page_ratio);
-			var lhs_y_end = ((change['lhs-y-end'] + ex.lhs_scroller.scrollTop()) * ex.visible_page_ratio) + 1;
-			var rhs_y_start = ((change['rhs-y-start'] + ex.rhs_scroller.scrollTop()) * ex.visible_page_ratio);
-			var rhs_y_end = ((change['rhs-y-end'] + ex.rhs_scroller.scrollTop()) * ex.visible_page_ratio) + 1;
+			var lhs_y_start = ((change['lhs-y-start'] + lhs_adjusted_scroll - scrollOffset) * ex.visible_page_ratio);
+			var lhs_y_end = ((change['lhs-y-end'] + lhs_adjusted_scroll - scrollOffset) * ex.visible_page_ratio) + 1;
+			var rhs_y_start = ((change['rhs-y-start'] + rhs_adjusted_scroll - scrollOffset) * ex.visible_page_ratio);
+			var rhs_y_end = ((change['rhs-y-end'] + rhs_adjusted_scroll - scrollOffset) * ex.visible_page_ratio) + 1;
 			this.trace('draw', 'marker calculated', lhs_y_start, lhs_y_end, rhs_y_start, rhs_y_end);
 
 			ctx_lhs.beginPath();
@@ -1432,10 +1436,10 @@ jQuery.extend(Mgly.CodeMirrorDiffView.prototype, {
 				continue;
 			}
 			
-			lhs_y_start = change['lhs-y-start'];
-			lhs_y_end = change['lhs-y-end'];
-			rhs_y_start = change['rhs-y-start'];
-			rhs_y_end = change['rhs-y-end'];
+			lhs_y_start = change['lhs-y-start'] - scrollOffset;
+			lhs_y_end = change['lhs-y-end'] - scrollOffset;
+			rhs_y_start = change['rhs-y-start'] - scrollOffset;
+			rhs_y_end = change['rhs-y-end'] - scrollOffset;
 			
 			var radius = 3;
 			
@@ -1519,11 +1523,11 @@ jQuery.extend(Mgly.CodeMirrorDiffView.prototype, {
 		ctx_rhs.fillStyle = this.settings.vpcolor;
 		
 		var lto = ex.clhs.height() * ex.visible_page_ratio;
-		var lfrom = (ex.lhs_scroller.scrollTop() / ex.gutter_height) * ex.clhs.height();
+		var lfrom = (lhs_adjusted_scroll / ex.gutter_height) * ex.clhs.height();
 		var rto = ex.crhs.height() * ex.visible_page_ratio;
-		var rfrom = (ex.rhs_scroller.scrollTop() / ex.gutter_height) * ex.crhs.height();
+		var rfrom = (rhs_adjusted_scroll / ex.gutter_height) * ex.crhs.height();
 		this.trace('draw', 'cls.height', ex.clhs.height());
-		this.trace('draw', 'lhs_scroller.scrollTop()', ex.lhs_scroller.scrollTop());
+		this.trace('draw', 'lhs_scroller.scrollTop()', lhs_adjusted_scroll);
 		this.trace('draw', 'gutter_height', ex.gutter_height);
 		this.trace('draw', 'visible_page_ratio', ex.visible_page_ratio);
 		this.trace('draw', 'lhs from', lfrom, 'lhs to', lto);


### PR DESCRIPTION
My page contains a mergely-editor dom element which has a position of `{top: 42, left: 0}`, causing
all of the canvas draws to be 42px too far down.  Because of this, I needed to offset the margin indicator draw calls by the `position` of the editor node.  I am not sure if this is the most reasonable solution to the problem, but it seemed like a bug that needed solving.

Let me know if there is a preferred way of doing this which is not in this PR.
