### PR TITLE
Collapse non-changes incl. tolerance

### DIFF
--- a/lib/mergely.js
+++ b/lib/mergely.js
@@ -389,6 +389,8 @@ jQuery.extend(Mgly.CodeMirrorDiffView.prototype, {
 			sidebar: true,
 			viewport: false,
 			ignorews: false,
+			show_equals: false,
+			collapse_tolerance: 3,
 			fadein: 'fast',
 			editor_width: '650px',
 			editor_height: '400px',
@@ -1098,6 +1100,16 @@ jQuery.extend(Mgly.CodeMirrorDiffView.prototype, {
 		}
 		return changes;
 	},
+
+	_get_marked_lns_to_collapse: function(editor, from, to) {
+		var to_ln = editor.lineInfo(to);
+		var tol = this.settings.collapse_tolerance;
+		return [editor,
+				{line:from + tol, ch:0},
+				{line:to - tol, ch:to_ln.text.length},
+				{collapsed: !this.settings.show_equals}];
+	},
+
 	_markup_changes: function (editor_name1, editor_name2, changes) {
 		jQuery('.merge-button').remove(); // clear
 		
@@ -1192,6 +1204,7 @@ jQuery.extend(Mgly.CodeMirrorDiffView.prototype, {
 		this.trace('change', 'markup rhs-editor time', timer.stop());
 		
 		// mark text deleted, LCS changes
+		var prev_llt = -1, prev_rlt = -1;
 		var marktext = [], i, j, k, p;
 		for (i = 0; this.settings.lcs && i < changes.length; ++i) {
 			var change = changes[i];
@@ -1199,11 +1212,12 @@ jQuery.extend(Mgly.CodeMirrorDiffView.prototype, {
 			var llt = change['lhs-line-to'] >= 0 ? change['lhs-line-to'] : 0;
 			var rlf = change['rhs-line-from'] >= 0 ? change['rhs-line-from'] : 0;
 			var rlt = change['rhs-line-to'] >= 0 ? change['rhs-line-to'] : 0;
-			
+
 			if (!this._is_change_in_view(vp, change)) {
 				// if the change is outside the viewport, skip
 				continue;
 			}
+
 			if (change['op'] == 'd') {
 				// apply delete to cross-out (left-hand side only)
 				var from = llf;
@@ -1244,7 +1258,27 @@ jQuery.extend(Mgly.CodeMirrorDiffView.prototype, {
 					);
 				}
 			}
+
+			if (llf > this.settings.collapse_tolerance &&
+				rlf > this.settings.collapse_tolerance)	{
+				// Fold non-changes between prev change and this one
+				marktext.push(this._get_marked_lns_to_collapse(led, prev_llt + 1, llf - 1));
+				marktext.push(this._get_marked_lns_to_collapse(red, prev_rlt + 1, rlf - 1));
+			}
+			prev_llt = llt;
+			prev_rlt = rlt;
 		}
+
+		// don't show non-changes after last change
+		if (changes.length != 0) {
+			var to_lhs_end = led.doc.size - 1 - this.settings.collapse_tolerance;
+			var to_rhs_end = red.doc.size - 1 - this.settings.collapse_tolerance;
+			if (prev_llt < to_lhs_end && prev_rlt < to_rhs_end) {
+				marktext.push(this._get_marked_lns_to_collapse(led, prev_llt + 1, to_lhs_end));
+				marktext.push(this._get_marked_lns_to_collapse(red, prev_rlt + 1, to_rhs_end));
+			}
+		}
+
 		this.trace('change', 'LCS marktext time', timer.stop());
 		
 		// mark changes outside closure
@@ -1408,8 +1442,8 @@ jQuery.extend(Mgly.CodeMirrorDiffView.prototype, {
 
 			this.trace('draw', change);
 			// margin indicators
-			var lhs_y_start = ((change['lhs-y-start'] + ex.lhs_scroller.scrollTop()) * ex.visible_page_ratio);
-			var lhs_y_end = ((change['lhs-y-end'] + ex.lhs_scroller.scrollTop()) * ex.visible_page_ratio) + 1;
+            var lhs_y_start = ((change['lhs-y-start'] + ex.lhs_scroller.scrollTop()) * ex.visible_page_ratio);
+            var lhs_y_end = ((change['lhs-y-end'] + ex.lhs_scroller.scrollTop()) * ex.visible_page_ratio) + 1;
 			var rhs_y_start = ((change['rhs-y-start'] + ex.rhs_scroller.scrollTop()) * ex.visible_page_ratio);
 			var rhs_y_end = ((change['rhs-y-end'] + ex.rhs_scroller.scrollTop()) * ex.visible_page_ratio) + 1;
 			this.trace('draw', 'marker calculated', lhs_y_start, lhs_y_end, rhs_y_start, rhs_y_end);


### PR DESCRIPTION
First glance of omitting non-changes by using the CodeMirror's text-marking collapse functionality.
This includes a tolerance of 3 lines before and after each change.
Further improvements under investigation (if you have any suggestions, please shoot):
- Replace collapsed coded with a space or line;
- Correct fancy markup drawings in the middle;
- Show collapsed line numbers.