### PR TITLE
Fixing XSS security issue.

### DIFF
--- a/editor/editor.php
+++ b/editor/editor.php
@@ -52,7 +52,7 @@ if (isset($_GET['debug'])) {
 	<script type="text/javascript" src="/Mergely/lib/searchcursor.js"></script>
 
 	<script type="text/javascript">
-        var key = '<?php echo $key; ?>';
+        var key = '<?php echo htmlspecialchars($key, ENT_QUOTES, 'UTF-8'); ?>';
         var isSample = key == 'usaindep';
     </script>
     


### PR DESCRIPTION
There is a XSS security issue in the Mergely Editor with which a attacker can run javascript in a victims browsers: http://www.mergely.com/editor?key=%27%2Balert(document.cookie)%2B%27

![XSS issue](http://i.imgur.com/LvFkVFf.png "XSS issue")

 I've fixed this by escaping the problematic values passed by get with htmlspecialchars. This would solve the problem.