### PR TITLE
Fix closing DIV tag on editor div example

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -60,7 +60,7 @@
 				<p>
 					Then, create a div for the editor:
 				</p>
-				<pre class="code">&lt;div id="compare"&gt;&lt;div&gt;</pre>
+				<pre class="code">&lt;div id="compare"&gt;&lt;/div&gt;</pre>
 				<p>
 					Then, initialize the 'compare' div with the mergely jquery plugin, setting
 					options as required:


### PR DESCRIPTION
Example code had two opening div tags previously.

The issue I opened was closed and I see it's changed on the site, figured I should fix it in the repository.